### PR TITLE
improve handling of poll rate, add benchmark timers

### DIFF
--- a/Demo/Demo_Cnc/opcserver.py
+++ b/Demo/Demo_Cnc/opcserver.py
@@ -40,7 +40,10 @@ async def g01(targets, feed, vars):
     # step widths
     s_widths = {}
     for axis in targets:
-        s_widths[axis] = (targets[axis] - prev_values[axis])/steps
+        if steps > 0:
+            s_widths[axis] = (targets[axis] - prev_values[axis])/steps
+        else:
+            s_widths[axis] = 0.0
 
     # loop, take a step each cycle
     # loop_time = 0.0
@@ -63,14 +66,14 @@ async def g01(targets, feed, vars):
         new_value = targets[axis]
         dv = ua.DataValue(ua.Variant(new_value, ua.VariantType.Double))
         await axis.write_value(dv)
-        await print_vars(vars)
+    await print_vars(vars)
 
     
-    after = datetime.now()
-    difference = after - before
-    time_elapsed = difference.total_seconds()
-    print("This g01 schould have taken ", t, "s")
-    print('This g01 took:', time_elapsed)
+    # after = datetime.now()
+    # difference = after - before
+    # time_elapsed = difference.total_seconds()
+    # print("This g01 schould have taken ", t, "s")
+    # print('This g01 took:', time_elapsed)
 
 
 
@@ -142,7 +145,11 @@ async def main():
 
             if cmd == 'start':
                 await(close_doors(vars))
-                await g01({vars['X']:1500, vars['Y']:800}, 1000, vars)
+                for i in range(5):
+                    await g01({vars['X']:500, vars['Y']:500, vars['Z']:500, vars['A']:0, vars['B']:0}, 5000, vars)
+                    await g01({vars['X']:100, vars['Y']:500, vars['Z']:500, vars['A']:180, vars['B']:180}, 5000, vars)
+                    await g01({vars['X']:100, vars['Y']:100, vars['Z']:200, vars['A']:0, vars['B']:0}, 5000, vars)
+                    await g01({vars['X']:500, vars['Y']:500, vars['Z']:500, vars['A']:180, vars['B']:180}, 5000, vars)
                 await(open_doors(vars))
 
             elif cmd == 'doors':

--- a/freecad.fcmcua/freecad/fcmcua/fcmcua_cmd.py
+++ b/freecad.fcmcua/freecad/fcmcua/fcmcua_cmd.py
@@ -91,14 +91,14 @@ class FcmcuaPanel:
             self.actu_list.append(ActuatorWidgets(hidden=True))
 
         # initialize opc client object
-        self.opc = OpcClient(self.axis_list, self.actu_list, self.addrLEdit.text(), self.pollSpin.value())
+        self.opc = OpcClient(self.axis_list, self.actu_list)
 
         # load previous settings from file params.fcmc
         self.load()
 
     
     def onConnClicked(self):
-        self.opc.start()
+        self.opc.start(self.addrLEdit.text(), self.pollSpin.value())
 
 
     def onDisconnClicked(self):
@@ -107,6 +107,7 @@ class FcmcuaPanel:
        
     def accept(self):
         self.save()
+        self.opc.stop()
         FreeCADGui.Control.closeDialog() #close the dialog
 
     

--- a/freecad.fcmcua/freecad/fcmcua/opc_cad_updater.py
+++ b/freecad.fcmcua/freecad/fcmcua/opc_cad_updater.py
@@ -15,11 +15,15 @@ class CadUpdater():
         self.actu_list = actu_list
         self.actu_values = actu_values
 
+        # prepare benchmarking
+        self.cycles = 0
+        self.total_rec = self.total_upd = 0.0
+
 
     def updateCAD(self):
         '''method to interact with FreeCAD model'''
-
-        print("update CAD")
+        b_upd = datetime.now()
+        
         # loop counter as an index for the values-list 
         itr = 0
 
@@ -37,12 +41,22 @@ class CadUpdater():
             itr += 1
 
         #recompute the CAD model
-        before = datetime.now()
+        b_rec = datetime.now()
         App.ActiveDocument.recompute()
-        after = datetime.now()
-        difference = after - before
-        time_elapsed = difference.total_seconds()
-        print('This recompute took:', time_elapsed)
+        
+        # benchmarking
+        a_rec = a_upd = datetime.now()
+        rec_cyc = (a_rec - b_rec).total_seconds()
+        upd_cyc = (a_upd - b_upd).total_seconds()
+
+        self.total_rec += rec_cyc
+        self.total_upd += upd_cyc
+        self.cycles += 1
+        if self.cycles > 0:
+            avg_rec = self.total_rec / self.cycles
+            avg_upd = self.total_upd / self.cycles
+            print("Average recompute time [s]: ", avg_rec)
+            print("Average updateCAD time [s]: ", avg_upd)
 
     def _getFcValues(self, doc, obj):
             try:    

--- a/freecad.fcmcua/freecad/fcmcua/opc_client.py
+++ b/freecad.fcmcua/freecad/fcmcua/opc_client.py
@@ -6,28 +6,32 @@ import FreeCADGui as Gui
 from fcmcua_actuator_logic import ActuatorLogic
 
 class OpcClient():
-    def __init__(self, axis_list, actu_list, address, poll_rate):
+    def __init__(self, axis_list, actu_list ):
         # OpcClient is initialised during workbench init
         
         # list of all axis configurations
         self.axis_list = axis_list
         # list of all actuator configurations
         self.actu_list = actu_list
-        # opc server url and poll rate
-        self.url = address
-        self.poll_rate = poll_rate
+
 
         self.actu_objs = []
         
 
-    def start(self):
+    def start(self, address, poll_rate):
         '''
         set-up and run a client-server connection to an opc ua server
         '''
+        # opc server url and poll rate
+        self.url = address
+        self.poll_rate = poll_rate
+
         # initialize opc client with address to the server
         client = Client(url=self.url)
+
         # loop control variable
         self.running = True
+
         try:
             client.connect()
             root = client.get_root_node()
@@ -72,10 +76,16 @@ class OpcClient():
         except:
             print("Exception while connecting to opc server")
 
-        
+        # prepare benchmarking
+        total_time = 0.0
+        cycles = 0
+
         # main loop
         while self.running:
             before = datetime.now()
+
+            # measure how long the cycle takes before sleeping
+            t_start = datetime.now()
             # get axis values from server
             for v in axes:
                 try:
@@ -93,7 +103,7 @@ class OpcClient():
                         pass
 
 
-            # get actuator values from actuator logic objects
+            # get actuator target values as calculated by the actuator logic objects
             for a in range(len(self.actu_list)):
                 actu_values[a] = self.actu_objs[a].get_current_pos(actu_triggers[a])
 
@@ -121,16 +131,30 @@ class OpcClient():
 
             for m in range(len(self.actu_list)):
                 prev_actu_values[m] = actu_values[m]
-    
-            # wait for poll_rate (ms) --> calculate seconds by 1/1000.0
-            time.sleep(self.poll_rate/1000.0)
+
             # updateGui to prevent the loop from blocking the GUI
             Gui.updateGui()
+    
+            # wait for poll_rate (ms) --> calculate seconds by 1/1000.0
+            # dont sleep longer than the poll rate, if the opc interaction takes a significant amount of time
+            t_end = datetime.now()
+            sleep = (self.poll_rate/1000) - (t_end - t_start).total_seconds()
+            if sleep > 0: 
+                time.sleep(sleep)
+                print("Slept for [s]: ", sleep)
+            print("calculated sleep time: ", sleep, "calculated from poll, time-diff: ", (self.poll_rate/1000), (t_end - t_start).total_seconds())
 
+
+            # benchmarking
             after = datetime.now()
-            difference = after - before
-            time_elapsed = difference.total_seconds()
-            print('This Gui update took:', time_elapsed)
+            time_elapsed = (after - before).total_seconds()
+
+            if updated:
+                total_time += time_elapsed
+                cycles += 1
+                if cycles > 0:
+                    avg = total_time / cycles
+                    print("Average Opc Cycle time [s]: ", avg)
            
         # after connection was stopped
         client.disconnect()


### PR DESCRIPTION
- opcclient always slept the duration of poll rate --> now only sleeps the difference to its own execution time
- poll_rate-spinBox and url-lineEdit were without function --> added argument call to OpcClient.start(address, spinBox)
- added timers to show execution time of recompute (FreeCAD), updateCAD method and OpcClient main loop